### PR TITLE
Configure project to use nightly toolchain

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,6 @@ jobs:
       - uses: actions/checkout@v5
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          toolchain: nightly-2025-12-05
           components: rust-src, rustfmt, clippy
       - run: cargo install taplo-cli --version 0.10.0 --locked
       - run: cargo install --path ./cargo-sgx --locked

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "nightly-2025-12-05"


### PR DESCRIPTION
This project [requires the Rust nightly toolchain](https://github.com/datachainlab/sgx-sdk-rs/blob/42e55e96e99d1e1fc016dee5fe46d8b3b9f833d1/README.md?plain=1#L50). The test workflow in GitHub actions already specifies nightly, and this PR specifies the toolchain at the repository level for all packages.