### PR TITLE
Return ENOSYS for some libc functions in Mac OS

### DIFF
--- a/sgx-urts/src/asyncio.rs
+++ b/sgx-urts/src/asyncio.rs
@@ -15,8 +15,18 @@
 // specific language governing permissions and limitations
 // under the License..
 
-use libc::{self, c_int, epoll_event, nfds_t, pollfd};
+use libc::{self, c_int, nfds_t, pollfd};
 use std::io::Error;
+
+#[cfg(target_os = "linux")]
+use libc::epoll_event;
+
+#[cfg(not(target_os = "linux"))]
+#[repr(C)]
+pub struct epoll_event {
+    pub events: u32,
+    pub u64: u64,
+}
 
 #[no_mangle]
 pub extern "C" fn u_poll_ocall(
@@ -38,59 +48,62 @@ pub extern "C" fn u_poll_ocall(
     ret
 }
 
-#[no_mangle]
-pub extern "C" fn u_epoll_create1_ocall(error: *mut c_int, flags: c_int) -> c_int {
-    let mut errno = 0;
-    let ret = unsafe { libc::epoll_create1(flags) };
-    if ret < 0 {
-        errno = Error::last_os_error().raw_os_error().unwrap_or(0);
-    }
-    if !error.is_null() {
-        unsafe {
-            *error = errno;
+linux_only_ocall! {
+    pub extern "C" fn u_epoll_create1_ocall(error: *mut c_int, flags: c_int) -> c_int {
+        let mut errno = 0;
+        let ret = unsafe { libc::epoll_create1(flags) };
+        if ret < 0 {
+            errno = Error::last_os_error().raw_os_error().unwrap_or(0);
         }
+        if !error.is_null() {
+            unsafe {
+                *error = errno;
+            }
+        }
+        ret
     }
-    ret
 }
 
-#[no_mangle]
-pub extern "C" fn u_epoll_ctl_ocall(
-    error: *mut c_int,
-    epfd: c_int,
-    op: c_int,
-    fd: c_int,
-    event: *mut epoll_event,
-) -> c_int {
-    let mut errno = 0;
-    let ret = unsafe { libc::epoll_ctl(epfd, op, fd, event) };
-    if ret < 0 {
-        errno = Error::last_os_error().raw_os_error().unwrap_or(0);
-    }
-    if !error.is_null() {
-        unsafe {
-            *error = errno;
+linux_only_ocall! {
+    pub extern "C" fn u_epoll_ctl_ocall(
+        error: *mut c_int,
+        epfd: c_int,
+        op: c_int,
+        fd: c_int,
+        event: *mut epoll_event,
+    ) -> c_int {
+        let mut errno = 0;
+        let ret = unsafe { libc::epoll_ctl(epfd, op, fd, event) };
+        if ret < 0 {
+            errno = Error::last_os_error().raw_os_error().unwrap_or(0);
         }
+        if !error.is_null() {
+            unsafe {
+                *error = errno;
+            }
+        }
+        ret
     }
-    ret
 }
 
-#[no_mangle]
-pub extern "C" fn u_epoll_wait_ocall(
-    error: *mut c_int,
-    epfd: c_int,
-    events: *mut epoll_event,
-    maxevents: c_int,
-    timeout: c_int,
-) -> c_int {
-    let mut errno = 0;
-    let ret = unsafe { libc::epoll_wait(epfd, events, maxevents, timeout) };
-    if ret < 0 {
-        errno = Error::last_os_error().raw_os_error().unwrap_or(0);
-    }
-    if !error.is_null() {
-        unsafe {
-            *error = errno;
+linux_only_ocall! {
+    pub extern "C" fn u_epoll_wait_ocall(
+        error: *mut c_int,
+        epfd: c_int,
+        events: *mut epoll_event,
+        maxevents: c_int,
+        timeout: c_int,
+    ) -> c_int {
+        let mut errno = 0;
+        let ret = unsafe { libc::epoll_wait(epfd, events, maxevents, timeout) };
+        if ret < 0 {
+            errno = Error::last_os_error().raw_os_error().unwrap_or(0);
         }
+        if !error.is_null() {
+            unsafe {
+                *error = errno;
+            }
+        }
+        ret
     }
-    ret
 }

--- a/sgx-urts/src/fd.rs
+++ b/sgx-urts/src/fd.rs
@@ -220,60 +220,62 @@ pub extern "C" fn u_sendfile_ocall(
     ret
 }
 
-#[no_mangle]
-pub extern "C" fn u_copy_file_range_ocall(
-    error: *mut c_int,
-    fd_in: c_int,
-    off_in: *mut loff_t,
-    fd_out: c_int,
-    off_out: *mut loff_t,
-    len: size_t,
-    flags: c_uint,
-) -> ssize_t {
-    let mut errno = 0;
-    let ret = unsafe {
-        libc::syscall(
-            libc::SYS_copy_file_range,
-            fd_in,
-            off_in,
-            fd_out,
-            off_out,
-            len,
-            flags,
-        ) as ssize_t
-    };
-    if ret < 0 {
-        errno = Error::last_os_error().raw_os_error().unwrap_or(0);
-    }
-    if !error.is_null() {
-        unsafe {
-            *error = errno;
+linux_only_ocall! {
+    pub extern "C" fn u_copy_file_range_ocall(
+        error: *mut c_int,
+        fd_in: c_int,
+        off_in: *mut loff_t,
+        fd_out: c_int,
+        off_out: *mut loff_t,
+        len: size_t,
+        flags: c_uint,
+    ) -> ssize_t {
+        let mut errno = 0;
+        let ret = unsafe {
+            libc::syscall(
+                libc::SYS_copy_file_range,
+                fd_in,
+                off_in,
+                fd_out,
+                off_out,
+                len,
+                flags,
+            ) as ssize_t
+        };
+        if ret < 0 {
+            errno = Error::last_os_error().raw_os_error().unwrap_or(0);
         }
+        if !error.is_null() {
+            unsafe {
+                *error = errno;
+            }
+        }
+        ret
     }
-    ret
 }
 
-#[no_mangle]
-pub extern "C" fn u_splice_ocall(
-    error: *mut c_int,
-    fd_in: c_int,
-    off_in: *mut loff_t,
-    fd_out: c_int,
-    off_out: *mut loff_t,
-    len: size_t,
-    flags: c_uint,
-) -> ssize_t {
-    let mut errno = 0;
-    let ret = unsafe { libc::splice(fd_in, off_in, fd_out, off_out, len, flags) };
-    if ret < 0 {
-        errno = Error::last_os_error().raw_os_error().unwrap_or(0);
-    }
-    if !error.is_null() {
-        unsafe {
-            *error = errno;
+linux_only_ocall! {
+    pub extern "C" fn u_splice_ocall(
+        error: *mut c_int,
+        fd_in: c_int,
+        off_in: *mut loff_t,
+        fd_out: c_int,
+        off_out: *mut loff_t,
+        len: size_t,
+        flags: c_uint,
+    ) -> ssize_t {
+        let mut errno = 0;
+        let ret = unsafe { libc::splice(fd_in, off_in, fd_out, off_out, len, flags) };
+        if ret < 0 {
+            errno = Error::last_os_error().raw_os_error().unwrap_or(0);
         }
+        if !error.is_null() {
+            unsafe {
+                *error = errno;
+            }
+        }
+        ret
     }
-    ret
 }
 
 #[no_mangle]
@@ -391,19 +393,20 @@ pub extern "C" fn u_dup_ocall(error: *mut c_int, oldfd: c_int) -> c_int {
     ret
 }
 
-#[no_mangle]
-pub extern "C" fn u_eventfd_ocall(error: *mut c_int, initval: c_uint, flags: c_int) -> c_int {
-    let mut errno = 0;
-    let ret = unsafe { libc::eventfd(initval, flags) };
-    if ret < 0 {
-        errno = Error::last_os_error().raw_os_error().unwrap_or(0);
-    }
-    if !error.is_null() {
-        unsafe {
-            *error = errno;
+linux_only_ocall! {
+    pub extern "C" fn u_eventfd_ocall(error: *mut c_int, initval: c_uint, flags: c_int) -> c_int {
+        let mut errno = 0;
+        let ret = unsafe { libc::eventfd(initval, flags) };
+        if ret < 0 {
+            errno = Error::last_os_error().raw_os_error().unwrap_or(0);
         }
+        if !error.is_null() {
+            unsafe {
+                *error = errno;
+            }
+        }
+        ret
     }
-    ret
 }
 
 #[no_mangle]

--- a/sgx-urts/src/file.rs
+++ b/sgx-urts/src/file.rs
@@ -597,7 +597,7 @@ pub extern "C" fn u_dirfd_ocall(error: *mut c_int, dirp: *mut DIR) -> c_int {
     ret
 }
 
-#[no_mangle]
+linux_only_ocall! {
 pub extern "C" fn u_fstatat64_ocall(
     error: *mut c_int,
     dirfd: c_int,
@@ -616,4 +616,5 @@ pub extern "C" fn u_fstatat64_ocall(
         }
     }
     ret
+}
 }

--- a/sgx-urts/src/lib.rs
+++ b/sgx-urts/src/lib.rs
@@ -18,6 +18,9 @@
 #![cfg_attr(feature = "signal", feature(linkage))]
 #![allow(clippy::not_unsafe_ptr_arg_deref)]
 
+#[macro_use]
+mod macros;
+
 pub mod asyncio;
 pub mod env;
 pub mod event;

--- a/sgx-urts/src/macros.rs
+++ b/sgx-urts/src/macros.rs
@@ -1,0 +1,48 @@
+/// Define an ocall function that only has a real implementation on Linux.
+/// On non-Linux targets, sets `*error = ENOSYS` and returns `-1`.
+///
+/// # Example
+///
+/// ```ignore
+/// linux_only_ocall! {
+///     pub extern "C" fn u_epoll_create1_ocall(error: *mut c_int, flags: c_int) -> c_int {
+///         let mut errno = 0;
+///         let ret = unsafe { libc::epoll_create1(flags) };
+///         if ret < 0 {
+///             errno = Error::last_os_error().raw_os_error().unwrap_or(0);
+///         }
+///         if !error.is_null() {
+///             unsafe {
+///                 *error = errno;
+///             }
+///         }
+///         ret
+///     }
+/// }
+/// ```
+macro_rules! linux_only_ocall {
+    (
+        pub extern "C" fn $name:ident(
+            $error:ident: *mut c_int
+            $(, $param:ident: $ty:ty)* $(,)?
+        ) -> $ret:ty
+            $linux_body:block
+    ) => {
+        #[cfg_attr(not(target_os = "linux"), allow(unused_variables))]
+        #[no_mangle]
+        pub extern "C" fn $name($error: *mut c_int $(, $param: $ty)*) -> $ret {
+            #[cfg(target_os = "linux")]
+            $linux_body
+
+            #[cfg(not(target_os = "linux"))]
+            {
+                if !$error.is_null() {
+                    unsafe {
+                        *$error = libc::ENOSYS;
+                    }
+                }
+                return -1;
+            }
+        }
+    };
+}

--- a/sgx-urts/src/pipe.rs
+++ b/sgx-urts/src/pipe.rs
@@ -33,17 +33,18 @@ pub extern "C" fn u_pipe_ocall(error: *mut c_int, fds: *mut c_int) -> c_int {
     ret
 }
 
-#[no_mangle]
-pub extern "C" fn u_pipe2_ocall(error: *mut c_int, fds: *mut c_int, flags: c_int) -> c_int {
-    let mut errno = 0;
-    let ret = unsafe { libc::pipe2(fds, flags) };
-    if ret < 0 {
-        errno = Error::last_os_error().raw_os_error().unwrap_or(0);
-    }
-    if !error.is_null() {
-        unsafe {
-            *error = errno;
+linux_only_ocall! {
+    pub extern "C" fn u_pipe2_ocall(error: *mut c_int, fds: *mut c_int, flags: c_int) -> c_int {
+        let mut errno = 0;
+        let ret = unsafe { libc::pipe2(fds, flags) };
+        if ret < 0 {
+            errno = Error::last_os_error().raw_os_error().unwrap_or(0);
         }
+        if !error.is_null() {
+            unsafe {
+                *error = errno;
+            }
+        }
+        ret
     }
-    ret
 }

--- a/sgx-urts/src/socket.rs
+++ b/sgx-urts/src/socket.rs
@@ -116,27 +116,28 @@ pub extern "C" fn u_accept_ocall(
     ret
 }
 
-#[no_mangle]
-pub extern "C" fn u_accept4_ocall(
-    error: *mut c_int,
-    sockfd: c_int,
-    addr: *mut sockaddr,
-    addrlen_in: socklen_t,
-    addrlen_out: *mut socklen_t,
-    flags: c_int,
-) -> c_int {
-    let mut errno = 0;
-    unsafe { *addrlen_out = addrlen_in };
-    let ret = unsafe { libc::accept4(sockfd, addr, addrlen_out, flags) };
-    if ret < 0 {
-        errno = Error::last_os_error().raw_os_error().unwrap_or(0);
-    }
-    if !error.is_null() {
-        unsafe {
-            *error = errno;
+linux_only_ocall! {
+    pub extern "C" fn u_accept4_ocall(
+        error: *mut c_int,
+        sockfd: c_int,
+        addr: *mut sockaddr,
+        addrlen_in: socklen_t,
+        addrlen_out: *mut socklen_t,
+        flags: c_int,
+    ) -> c_int {
+        let mut errno = 0;
+        unsafe { *addrlen_out = addrlen_in };
+        let ret = unsafe { libc::accept4(sockfd, addr, addrlen_out, flags) };
+        if ret < 0 {
+            errno = Error::last_os_error().raw_os_error().unwrap_or(0);
         }
+        if !error.is_null() {
+            unsafe {
+                *error = errno;
+            }
+        }
+        ret
     }
-    ret
 }
 
 #[no_mangle]

--- a/sgx-urts/src/sys.rs
+++ b/sgx-urts/src/sys.rs
@@ -15,8 +15,15 @@
 // specific language governing permissions and limitations
 // under the License..
 
-use libc::{self, c_int, c_long, c_ulong, cpu_set_t, pid_t, size_t};
+use libc::{self, c_int, c_long, c_ulong, pid_t, size_t};
 use std::io::Error;
+
+#[cfg(target_os = "linux")]
+use libc::cpu_set_t;
+
+#[cfg(not(target_os = "linux"))]
+#[allow(non_camel_case_types)]
+type cpu_set_t = libc::c_void;
 
 #[no_mangle]
 pub extern "C" fn u_sysconf_ocall(error: *mut c_int, name: c_int) -> c_long {
@@ -33,64 +40,67 @@ pub extern "C" fn u_sysconf_ocall(error: *mut c_int, name: c_int) -> c_long {
     ret
 }
 
-#[no_mangle]
-pub extern "C" fn u_prctl_ocall(
-    error: *mut c_int,
-    option: c_int,
-    arg2: c_ulong,
-    arg3: c_ulong,
-    arg4: c_ulong,
-    arg5: c_ulong,
-) -> c_int {
-    let mut errno = 0;
-    let ret = unsafe { libc::prctl(option, arg2, arg3, arg4, arg5) };
-    if ret < 0 {
-        errno = Error::last_os_error().raw_os_error().unwrap_or(0);
-    }
-    if !error.is_null() {
-        unsafe {
-            *error = errno;
+linux_only_ocall! {
+    pub extern "C" fn u_prctl_ocall(
+        error: *mut c_int,
+        option: c_int,
+        arg2: c_ulong,
+        arg3: c_ulong,
+        arg4: c_ulong,
+        arg5: c_ulong,
+    ) -> c_int {
+        let mut errno = 0;
+        let ret = unsafe { libc::prctl(option, arg2, arg3, arg4, arg5) };
+        if ret < 0 {
+            errno = Error::last_os_error().raw_os_error().unwrap_or(0);
         }
+        if !error.is_null() {
+            unsafe {
+                *error = errno;
+            }
+        }
+        ret
     }
-    ret
 }
 
-#[no_mangle]
-pub extern "C" fn u_sched_setaffinity_ocall(
-    error: *mut c_int,
-    pid: pid_t,
-    cpusetsize: size_t,
-    mask: *const cpu_set_t,
-) -> c_int {
-    let mut errno = 0;
-    let ret = unsafe { libc::sched_setaffinity(pid, cpusetsize, mask) };
-    if ret < 0 {
-        errno = Error::last_os_error().raw_os_error().unwrap_or(0);
-    }
-    if !error.is_null() {
-        unsafe {
-            *error = errno;
+linux_only_ocall! {
+    pub extern "C" fn u_sched_setaffinity_ocall(
+        error: *mut c_int,
+        pid: pid_t,
+        cpusetsize: size_t,
+        mask: *const cpu_set_t,
+    ) -> c_int {
+        let mut errno = 0;
+        let ret = unsafe { libc::sched_setaffinity(pid, cpusetsize, mask) };
+        if ret < 0 {
+            errno = Error::last_os_error().raw_os_error().unwrap_or(0);
         }
+        if !error.is_null() {
+            unsafe {
+                *error = errno;
+            }
+        }
+        ret
     }
-    ret
 }
 
-#[no_mangle]
-pub extern "C" fn u_sched_getaffinity_ocall(
-    error: *mut c_int,
-    pid: pid_t,
-    cpusetsize: size_t,
-    mask: *mut cpu_set_t,
-) -> c_int {
-    let mut errno = 0;
-    let ret = unsafe { libc::sched_getaffinity(pid, cpusetsize, mask) };
-    if ret < 0 {
-        errno = Error::last_os_error().raw_os_error().unwrap_or(0);
-    }
-    if !error.is_null() {
-        unsafe {
-            *error = errno;
+linux_only_ocall! {
+    pub extern "C" fn u_sched_getaffinity_ocall(
+        error: *mut c_int,
+        pid: pid_t,
+        cpusetsize: size_t,
+        mask: *mut cpu_set_t,
+    ) -> c_int {
+        let mut errno = 0;
+        let ret = unsafe { libc::sched_getaffinity(pid, cpusetsize, mask) };
+        if ret < 0 {
+            errno = Error::last_os_error().raw_os_error().unwrap_or(0);
         }
+        if !error.is_null() {
+            unsafe {
+                *error = errno;
+            }
+        }
+        ret
     }
-    ret
 }


### PR DESCRIPTION
This change is one step towards being able to compile sgx-urts in Mac OS. The functions in this commit are difficult to port to Mac and it may not be worth doing, so a real implementation for each of them can be considered when the need arises.