### PR TITLE
Support compiling on aarch64

### DIFF
--- a/sgx-alloc/src/system.rs
+++ b/sgx-alloc/src/system.rs
@@ -34,11 +34,8 @@ const MIN_ALIGN: usize = 8;
 
 // The alignment of sgx tlibc is 16
 // https://github.com/intel/linux-sgx/blob/master/sdk/tlibc/stdlib/malloc.c#L541
-#[cfg(target_arch = "x86_64")]
-const MIN_ALIGN: usize = 16;
-
-// See https://github.com/rust-lang/rust/blob/b2fabe39bde5174e8d728bb85f2b8d0572c35b74/library/std/src/sys/alloc/mod.rs#L32-L44
-#[cfg(target_arch = "aarch64")]
+// See also https://github.com/rust-lang/rust/blob/b2fabe39bde5174e8d728bb85f2b8d0572c35b74/library/std/src/sys/alloc/mod.rs#L32-L44
+#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
 const MIN_ALIGN: usize = 16;
 
 pub struct System;

--- a/sgx-alloc/src/system.rs
+++ b/sgx-alloc/src/system.rs
@@ -37,6 +37,10 @@ const MIN_ALIGN: usize = 8;
 #[cfg(target_arch = "x86_64")]
 const MIN_ALIGN: usize = 16;
 
+// See https://github.com/rust-lang/rust/blob/b2fabe39bde5174e8d728bb85f2b8d0572c35b74/library/std/src/sys/alloc/mod.rs#L32-L44
+#[cfg(target_arch = "aarch64")]
+const MIN_ALIGN: usize = 16;
+
 pub struct System;
 
 impl System {
@@ -266,7 +270,16 @@ mod platform {
 
     #[inline]
     unsafe fn aligned_malloc(layout: &Layout) -> *mut u8 {
-        libc::memalign(layout.align(), layout.size()) as *mut u8
+        let mut ptr: *mut c_void = ptr::null_mut();
+        // alignment must be a multiple of sizeof(void *)
+        // See https://github.com/rust-lang/rust/blob/b2fabe39bde5174e8d728bb85f2b8d0572c35b74/library/std/src/sys/alloc/unix.rs#L80-L82
+        let align = layout.align().max(core::mem::size_of::<usize>());
+        let ret = libc::posix_memalign(&mut ptr, align, layout.size());
+        if ret == 0 {
+            ptr as *mut u8
+        } else {
+            ptr::null_mut()
+        }
     }
 }
 
@@ -278,6 +291,6 @@ mod libc {
         pub fn malloc(size: size_t) -> *mut c_void;
         pub fn realloc(p: *mut c_void, size: size_t) -> *mut c_void;
         pub fn free(p: *mut c_void);
-        pub fn memalign(align: size_t, size: size_t) -> *mut c_void;
+        pub fn posix_memalign(memptr: *mut *mut c_void, alignment: size_t, size: size_t) -> i32;
     }
 }

--- a/sgx-build/src/lib.rs
+++ b/sgx-build/src/lib.rs
@@ -41,6 +41,26 @@ impl FromStr for SgxMode {
     }
 }
 
+/// SGX target architecture
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SgxArch {
+    X86, // x86
+    X64, // x86_64
+    Other(String),
+}
+
+impl FromStr for SgxArch {
+    type Err = std::convert::Infallible;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(match s {
+            "x86" => SgxArch::X86,
+            "x64" | "x86_64" => SgxArch::X64,
+            other => SgxArch::Other(other.to_string()),
+        })
+    }
+}
+
 /// CVE-2020-0551 (Load Value Injection) mitigation strategy
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum Cve20200551Mitigation {
@@ -87,7 +107,7 @@ pub struct EdlOutput {
 pub struct SgxBuilder {
     sgx_sdk: PathBuf,
     sgx_mode: SgxMode,
-    sgx_arch: String,
+    sgx_arch: SgxArch,
     debug: bool,
     mitigation_cve_2020_0551: Cve20200551Mitigation,
     gcc_version: Option<(u32, u32, u32)>,
@@ -101,13 +121,18 @@ impl SgxBuilder {
             .ok()
             .and_then(|s| SgxMode::from_str(&s).ok())
             .unwrap_or_default();
-        let sgx_arch = env::var("SGX_ARCH").unwrap_or_else(|_| {
-            if cfg!(target_pointer_width = "32") {
-                "x86".to_string()
-            } else {
-                "x64".to_string()
-            }
-        });
+        let sgx_arch: SgxArch = env::var("SGX_ARCH")
+            .unwrap_or_else(|_| {
+                if cfg!(target_arch = "x86") {
+                    "x86".to_string()
+                } else if cfg!(target_arch = "x86_64") {
+                    "x64".to_string()
+                } else {
+                    std::env::consts::ARCH.to_string()
+                }
+            })
+            .parse()
+            .unwrap(); // Parsing into SgxArch is infallible
         let debug = env::var("SGX_DEBUG").unwrap_or_default() == "1" || cfg!(debug_assertions);
         let mitigation_cve_2020_0551 = match env::var("MITIGATION_CVE_2020_0551")
             .or_else(|_| env::var("MITIGATION-CVE-2020-0551"))
@@ -203,17 +228,18 @@ impl SgxBuilder {
 
     /// Get SDK library path based on architecture
     pub fn get_sdk_lib_path(&self) -> PathBuf {
-        match self.sgx_arch.as_str() {
-            "x86" => self.sgx_sdk.join("lib"),
-            _ => self.sgx_sdk.join("lib64"),
+        match self.sgx_arch {
+            SgxArch::X86 => self.sgx_sdk.join("lib"),
+            SgxArch::X64 | SgxArch::Other(_) => self.sgx_sdk.join("lib64"),
         }
     }
 
     /// Get architecture-specific flags
-    fn get_arch_flags(&self) -> &'static str {
-        match self.sgx_arch.as_str() {
-            "x86" => "-m32",
-            _ => "-m64",
+    fn get_arch_flags(&self) -> Option<&'static str> {
+        match self.sgx_arch {
+            SgxArch::X86 => Some("-m32"),
+            SgxArch::X64 => Some("-m64"),
+            SgxArch::Other(_) => None,
         }
     }
 
@@ -298,9 +324,12 @@ impl SgxBuilder {
 
         build
             .file(c_file)
-            .flag(self.get_arch_flags())
             .include(self.sgx_sdk.join("include"))
             .include(c_file_dir);
+
+        if let Some(arch_flag) = self.get_arch_flags() {
+            build.flag(arch_flag);
+        }
 
         // Common flags
         self.apply_common_flags(&mut build);
@@ -333,10 +362,15 @@ impl SgxBuilder {
         build.flag("-fdata-sections");
 
         // Architecture-specific defines
-        match self.sgx_arch.as_str() {
-            "x86" => build.define("ITT_ARCH_IA32", None),
-            _ => build.define("ITT_ARCH_IA64", None),
-        };
+        match self.sgx_arch {
+            SgxArch::X86 => {
+                build.define("ITT_ARCH_IA32", None);
+            }
+            SgxArch::X64 => {
+                build.define("ITT_ARCH_IA64", None);
+            }
+            SgxArch::Other(_) => {}
+        }
 
         // Warning flags
         build
@@ -475,7 +509,9 @@ impl SgxBuilder {
         println!("cargo:rustc-link-arg=-Wl,--gc-sections");
 
         // Architecture-specific flags
-        println!("cargo:rustc-link-arg={}", self.get_arch_flags());
+        if let Some(arch_flag) = self.get_arch_flags() {
+            println!("cargo:rustc-link-arg={arch_flag}");
+        }
     }
 
     #[allow(clippy::needless_doctest_main)]
@@ -588,10 +624,14 @@ impl SgxBuilder {
     ) -> Result<(), String> {
         let mut cc_build = cc::Build::new();
 
-        cc_build
-            .target("x86_64-unknown-linux-gnu")
-            .host("x86_64-unknown-linux-gnu")
-            .opt_level(if self.debug { 0 } else { 2 });
+        let target_triple = match self.sgx_arch {
+            SgxArch::X86 => "i686-unknown-linux-gnu".to_string(),
+            SgxArch::X64 => "x86_64-unknown-linux-gnu".to_string(),
+            SgxArch::Other(ref arch) => format!("{arch}-unknown-linux-gnu"),
+        };
+        cc_build.target(&target_triple).host(&target_triple);
+
+        cc_build.opt_level(if self.debug { 0 } else { 2 });
 
         // Enable cargo metadata output in debug mode
         cc_build.cargo_metadata(self.debug);
@@ -599,7 +639,9 @@ impl SgxBuilder {
         let mut cmd = cc_build.get_compiler().to_command();
 
         // Architecture flag
-        cmd.arg(self.get_arch_flags());
+        if let Some(arch_flag) = self.get_arch_flags() {
+            cmd.arg(arch_flag);
+        }
 
         // Common linker flags
         cmd.args([

--- a/sgx-build/src/lib.rs
+++ b/sgx-build/src/lib.rs
@@ -44,20 +44,21 @@ impl FromStr for SgxMode {
 /// SGX target architecture
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum SgxArch {
-    X86, // x86
-    X64, // x86_64
-    Other(String),
+    X86,
+    X64,
+    Aarch64,
 }
 
 impl FromStr for SgxArch {
-    type Err = std::convert::Infallible;
+    type Err = String;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        Ok(match s {
-            "x86" => SgxArch::X86,
-            "x64" | "x86_64" => SgxArch::X64,
-            other => SgxArch::Other(other.to_string()),
-        })
+        match s {
+            "x86" => Ok(SgxArch::X86),
+            "x64" | "x86_64" => Ok(SgxArch::X64),
+            "aarch64" => Ok(SgxArch::Aarch64),
+            other => Err(format!("Unsupported SGX architecture: {other}")),
+        }
     }
 }
 
@@ -127,12 +128,14 @@ impl SgxBuilder {
                     "x86".to_string()
                 } else if cfg!(target_arch = "x86_64") {
                     "x64".to_string()
+                } else if cfg!(target_arch = "aarch64") {
+                    "aarch64".to_string()
                 } else {
                     std::env::consts::ARCH.to_string()
                 }
             })
             .parse()
-            .unwrap(); // Parsing into SgxArch is infallible
+            .unwrap_or_else(|e| panic!("Invalid SGX_ARCH value: {e}"));
         let debug = env::var("SGX_DEBUG").unwrap_or_default() == "1" || cfg!(debug_assertions);
         let mitigation_cve_2020_0551 = match env::var("MITIGATION_CVE_2020_0551")
             .or_else(|_| env::var("MITIGATION-CVE-2020-0551"))
@@ -230,7 +233,7 @@ impl SgxBuilder {
     pub fn get_sdk_lib_path(&self) -> PathBuf {
         match self.sgx_arch {
             SgxArch::X86 => self.sgx_sdk.join("lib"),
-            SgxArch::X64 | SgxArch::Other(_) => self.sgx_sdk.join("lib64"),
+            SgxArch::X64 | SgxArch::Aarch64 => self.sgx_sdk.join("lib64"),
         }
     }
 
@@ -239,7 +242,7 @@ impl SgxBuilder {
         match self.sgx_arch {
             SgxArch::X86 => Some("-m32"),
             SgxArch::X64 => Some("-m64"),
-            SgxArch::Other(_) => None,
+            SgxArch::Aarch64 => None,
         }
     }
 
@@ -369,7 +372,7 @@ impl SgxBuilder {
             SgxArch::X64 => {
                 build.define("ITT_ARCH_IA64", None);
             }
-            SgxArch::Other(_) => {}
+            SgxArch::Aarch64 => {}
         }
 
         // Warning flags
@@ -627,7 +630,7 @@ impl SgxBuilder {
         let target_triple = match self.sgx_arch {
             SgxArch::X86 => "i686-unknown-linux-gnu".to_string(),
             SgxArch::X64 => "x86_64-unknown-linux-gnu".to_string(),
-            SgxArch::Other(ref arch) => format!("{arch}-unknown-linux-gnu"),
+            SgxArch::Aarch64 => "aarch64-unknown-linux-gnu".to_string(),
         };
         cc_build.target(&target_triple).host(&target_triple);
 

--- a/sgx-build/src/lib.rs
+++ b/sgx-build/src/lib.rs
@@ -136,6 +136,9 @@ impl SgxBuilder {
             })
             .parse()
             .unwrap_or_else(|e| panic!("Invalid SGX_ARCH value: {e}"));
+        if sgx_arch == SgxArch::Aarch64 && sgx_mode != SgxMode::Simulation {
+            panic!("Only SW (simulation) mode is supported for aarch64")
+        }
         let debug = env::var("SGX_DEBUG").unwrap_or_default() == "1" || cfg!(debug_assertions);
         let mitigation_cve_2020_0551 = match env::var("MITIGATION_CVE_2020_0551")
             .or_else(|_| env::var("MITIGATION-CVE-2020-0551"))

--- a/sgx-urts/src/asyncio.rs
+++ b/sgx-urts/src/asyncio.rs
@@ -15,8 +15,18 @@
 // specific language governing permissions and limitations
 // under the License..
 
-use libc::{self, c_int, epoll_event, nfds_t, pollfd};
+use libc::{self, c_int, nfds_t, pollfd};
 use std::io::Error;
+
+#[cfg(target_os = "linux")]
+use libc::epoll_event;
+
+#[cfg(not(target_os = "linux"))]
+#[repr(C)]
+pub struct epoll_event {
+    pub events: u32,
+    pub u64: u64,
+}
 
 #[no_mangle]
 pub extern "C" fn u_poll_ocall(
@@ -38,59 +48,62 @@ pub extern "C" fn u_poll_ocall(
     ret
 }
 
-#[no_mangle]
-pub extern "C" fn u_epoll_create1_ocall(error: *mut c_int, flags: c_int) -> c_int {
-    let mut errno = 0;
-    let ret = unsafe { libc::epoll_create1(flags) };
-    if ret < 0 {
-        errno = Error::last_os_error().raw_os_error().unwrap_or(0);
-    }
-    if !error.is_null() {
-        unsafe {
-            *error = errno;
+linux_only_ocall! {
+    pub extern "C" fn u_epoll_create1_ocall(error: *mut c_int, flags: c_int) -> c_int {
+        let mut errno = 0;
+        let ret = unsafe { libc::epoll_create1(flags) };
+        if ret < 0 {
+            errno = Error::last_os_error().raw_os_error().unwrap_or(0);
         }
+        if !error.is_null() {
+            unsafe {
+                *error = errno;
+            }
+        }
+        ret
     }
-    ret
 }
 
-#[no_mangle]
-pub extern "C" fn u_epoll_ctl_ocall(
-    error: *mut c_int,
-    epfd: c_int,
-    op: c_int,
-    fd: c_int,
-    event: *mut epoll_event,
-) -> c_int {
-    let mut errno = 0;
-    let ret = unsafe { libc::epoll_ctl(epfd, op, fd, event) };
-    if ret < 0 {
-        errno = Error::last_os_error().raw_os_error().unwrap_or(0);
-    }
-    if !error.is_null() {
-        unsafe {
-            *error = errno;
+linux_only_ocall! {
+    pub extern "C" fn u_epoll_ctl_ocall(
+        error: *mut c_int,
+        epfd: c_int,
+        op: c_int,
+        fd: c_int,
+        event: *mut epoll_event,
+    ) -> c_int {
+        let mut errno = 0;
+        let ret = unsafe { libc::epoll_ctl(epfd, op, fd, event) };
+        if ret < 0 {
+            errno = Error::last_os_error().raw_os_error().unwrap_or(0);
         }
+        if !error.is_null() {
+            unsafe {
+                *error = errno;
+            }
+        }
+        ret
     }
-    ret
 }
 
-#[no_mangle]
-pub extern "C" fn u_epoll_wait_ocall(
-    error: *mut c_int,
-    epfd: c_int,
-    events: *mut epoll_event,
-    maxevents: c_int,
-    timeout: c_int,
-) -> c_int {
-    let mut errno = 0;
-    let ret = unsafe { libc::epoll_wait(epfd, events, maxevents, timeout) };
-    if ret < 0 {
-        errno = Error::last_os_error().raw_os_error().unwrap_or(0);
-    }
-    if !error.is_null() {
-        unsafe {
-            *error = errno;
+linux_only_ocall! {
+    pub extern "C" fn u_epoll_wait_ocall(
+        error: *mut c_int,
+        epfd: c_int,
+        events: *mut epoll_event,
+        maxevents: c_int,
+        timeout: c_int,
+    ) -> c_int {
+        let mut errno = 0;
+        let ret = unsafe { libc::epoll_wait(epfd, events, maxevents, timeout) };
+        if ret < 0 {
+            errno = Error::last_os_error().raw_os_error().unwrap_or(0);
         }
+        if !error.is_null() {
+            unsafe {
+                *error = errno;
+            }
+        }
+        ret
     }
-    ret
 }

--- a/sgx-urts/src/fd.rs
+++ b/sgx-urts/src/fd.rs
@@ -220,60 +220,62 @@ pub extern "C" fn u_sendfile_ocall(
     ret
 }
 
-#[no_mangle]
-pub extern "C" fn u_copy_file_range_ocall(
-    error: *mut c_int,
-    fd_in: c_int,
-    off_in: *mut loff_t,
-    fd_out: c_int,
-    off_out: *mut loff_t,
-    len: size_t,
-    flags: c_uint,
-) -> ssize_t {
-    let mut errno = 0;
-    let ret = unsafe {
-        libc::syscall(
-            libc::SYS_copy_file_range,
-            fd_in,
-            off_in,
-            fd_out,
-            off_out,
-            len,
-            flags,
-        ) as ssize_t
-    };
-    if ret < 0 {
-        errno = Error::last_os_error().raw_os_error().unwrap_or(0);
-    }
-    if !error.is_null() {
-        unsafe {
-            *error = errno;
+linux_only_ocall! {
+    pub extern "C" fn u_copy_file_range_ocall(
+        error: *mut c_int,
+        fd_in: c_int,
+        off_in: *mut loff_t,
+        fd_out: c_int,
+        off_out: *mut loff_t,
+        len: size_t,
+        flags: c_uint,
+    ) -> ssize_t {
+        let mut errno = 0;
+        let ret = unsafe {
+            libc::syscall(
+                libc::SYS_copy_file_range,
+                fd_in,
+                off_in,
+                fd_out,
+                off_out,
+                len,
+                flags,
+            ) as ssize_t
+        };
+        if ret < 0 {
+            errno = Error::last_os_error().raw_os_error().unwrap_or(0);
         }
+        if !error.is_null() {
+            unsafe {
+                *error = errno;
+            }
+        }
+        ret
     }
-    ret
 }
 
-#[no_mangle]
-pub extern "C" fn u_splice_ocall(
-    error: *mut c_int,
-    fd_in: c_int,
-    off_in: *mut loff_t,
-    fd_out: c_int,
-    off_out: *mut loff_t,
-    len: size_t,
-    flags: c_uint,
-) -> ssize_t {
-    let mut errno = 0;
-    let ret = unsafe { libc::splice(fd_in, off_in, fd_out, off_out, len, flags) };
-    if ret < 0 {
-        errno = Error::last_os_error().raw_os_error().unwrap_or(0);
-    }
-    if !error.is_null() {
-        unsafe {
-            *error = errno;
+linux_only_ocall! {
+    pub extern "C" fn u_splice_ocall(
+        error: *mut c_int,
+        fd_in: c_int,
+        off_in: *mut loff_t,
+        fd_out: c_int,
+        off_out: *mut loff_t,
+        len: size_t,
+        flags: c_uint,
+    ) -> ssize_t {
+        let mut errno = 0;
+        let ret = unsafe { libc::splice(fd_in, off_in, fd_out, off_out, len, flags) };
+        if ret < 0 {
+            errno = Error::last_os_error().raw_os_error().unwrap_or(0);
         }
+        if !error.is_null() {
+            unsafe {
+                *error = errno;
+            }
+        }
+        ret
     }
-    ret
 }
 
 #[no_mangle]
@@ -391,19 +393,20 @@ pub extern "C" fn u_dup_ocall(error: *mut c_int, oldfd: c_int) -> c_int {
     ret
 }
 
-#[no_mangle]
-pub extern "C" fn u_eventfd_ocall(error: *mut c_int, initval: c_uint, flags: c_int) -> c_int {
-    let mut errno = 0;
-    let ret = unsafe { libc::eventfd(initval, flags) };
-    if ret < 0 {
-        errno = Error::last_os_error().raw_os_error().unwrap_or(0);
-    }
-    if !error.is_null() {
-        unsafe {
-            *error = errno;
+linux_only_ocall! {
+    pub extern "C" fn u_eventfd_ocall(error: *mut c_int, initval: c_uint, flags: c_int) -> c_int {
+        let mut errno = 0;
+        let ret = unsafe { libc::eventfd(initval, flags) };
+        if ret < 0 {
+            errno = Error::last_os_error().raw_os_error().unwrap_or(0);
         }
+        if !error.is_null() {
+            unsafe {
+                *error = errno;
+            }
+        }
+        ret
     }
-    ret
 }
 
 #[no_mangle]

--- a/sgx-urts/src/fd.rs
+++ b/sgx-urts/src/fd.rs
@@ -15,9 +15,24 @@
 // specific language governing permissions and limitations
 // under the License..
 
+use libc::{self, c_int, c_uint, c_ulong, c_void, iovec, off_t, size_t, ssize_t, timespec};
+
+#[cfg(target_os = "linux")]
+use libc::loff_t;
+
+#[cfg(not(target_os = "linux"))]
+#[allow(non_camel_case_types)]
+type loff_t = i64;
+
+#[cfg(not(all(target_os = "linux", target_pointer_width = "32")))]
 use libc::{
-    self, c_int, c_uint, c_ulong, c_void, iovec, loff_t, off64_t, off_t, size_t, ssize_t, timespec,
+    off_t as off64_t, pread as pread64, preadv as preadv64, pwrite as pwrite64,
+    pwritev as pwritev64,
 };
+
+#[cfg(all(target_os = "linux", target_pointer_width = "32"))]
+use libc::{off64_t, pread64, preadv64, pwrite64, pwritev64};
+
 use std::io::Error;
 
 #[no_mangle]
@@ -49,7 +64,7 @@ pub extern "C" fn u_pread64_ocall(
     offset: off64_t,
 ) -> ssize_t {
     let mut errno = 0;
-    let ret = unsafe { libc::pread64(fd, buf, count, offset) };
+    let ret = unsafe { pread64(fd, buf, count, offset) };
     if ret < 0 {
         errno = Error::last_os_error().raw_os_error().unwrap_or(0);
     }
@@ -90,7 +105,7 @@ pub extern "C" fn u_preadv64_ocall(
     offset: off64_t,
 ) -> ssize_t {
     let mut errno = 0;
-    let ret = unsafe { libc::preadv64(fd, iov, iovcnt, offset) };
+    let ret = unsafe { preadv64(fd, iov, iovcnt, offset) };
     if ret < 0 {
         errno = Error::last_os_error().raw_os_error().unwrap_or(0);
     }
@@ -131,7 +146,7 @@ pub extern "C" fn u_pwrite64_ocall(
     offset: off64_t,
 ) -> ssize_t {
     let mut errno = 0;
-    let ret = unsafe { libc::pwrite64(fd, buf, count, offset) };
+    let ret = unsafe { pwrite64(fd, buf, count, offset) };
     if ret < 0 {
         errno = Error::last_os_error().raw_os_error().unwrap_or(0);
     }
@@ -172,7 +187,7 @@ pub extern "C" fn u_pwritev64_ocall(
     offset: off64_t,
 ) -> ssize_t {
     let mut errno = 0;
-    let ret = unsafe { libc::pwritev64(fd, iov, iovcnt, offset) };
+    let ret = unsafe { pwritev64(fd, iov, iovcnt, offset) };
     if ret < 0 {
         errno = Error::last_os_error().raw_os_error().unwrap_or(0);
     }

--- a/sgx-urts/src/fd.rs
+++ b/sgx-urts/src/fd.rs
@@ -199,25 +199,26 @@ pub extern "C" fn u_pwritev64_ocall(
     ret
 }
 
-#[no_mangle]
-pub extern "C" fn u_sendfile_ocall(
-    error: *mut c_int,
-    out_fd: c_int,
-    in_fd: c_int,
-    offset: *mut off_t,
-    count: size_t,
-) -> ssize_t {
-    let mut errno = 0;
-    let ret = unsafe { libc::sendfile(out_fd, in_fd, offset, count) };
-    if ret < 0 {
-        errno = Error::last_os_error().raw_os_error().unwrap_or(0);
-    }
-    if !error.is_null() {
-        unsafe {
-            *error = errno;
+linux_only_ocall! {
+    pub extern "C" fn u_sendfile_ocall(
+        error: *mut c_int,
+        out_fd: c_int,
+        in_fd: c_int,
+        offset: *mut off_t,
+        count: size_t,
+    ) -> ssize_t {
+        let mut errno = 0;
+        let ret = unsafe { libc::sendfile(out_fd, in_fd, offset, count) };
+        if ret < 0 {
+            errno = Error::last_os_error().raw_os_error().unwrap_or(0);
         }
+        if !error.is_null() {
+            unsafe {
+                *error = errno;
+            }
+        }
+        ret
     }
-    ret
 }
 
 linux_only_ocall! {

--- a/sgx-urts/src/file.rs
+++ b/sgx-urts/src/file.rs
@@ -597,7 +597,7 @@ pub extern "C" fn u_dirfd_ocall(error: *mut c_int, dirp: *mut DIR) -> c_int {
     ret
 }
 
-#[no_mangle]
+linux_only_ocall! {
 pub extern "C" fn u_fstatat64_ocall(
     error: *mut c_int,
     dirfd: c_int,
@@ -616,4 +616,5 @@ pub extern "C" fn u_fstatat64_ocall(
         }
     }
     ret
+}
 }

--- a/sgx-urts/src/file.rs
+++ b/sgx-urts/src/file.rs
@@ -15,11 +15,22 @@
 // specific language governing permissions and limitations
 // under the License..
 
-use libc::{
-    self, c_char, c_int, dirent64, mode_t, off64_t, off_t, size_t, ssize_t, stat, stat64, DIR,
-};
+use libc::{self, c_char, c_int, mode_t, off_t, size_t, ssize_t, stat, DIR};
 use std::io::Error;
 use std::ptr;
+
+#[cfg(not(all(target_os = "linux", target_pointer_width = "32")))]
+use libc::{
+    dirent as dirent64, fstat as fstat64, fstatat as fstatat64, ftruncate as ftruncate64,
+    lseek as lseek64, lstat as lstat64, off_t as off64_t, open as open64, readdir_r as readdir64_r,
+    stat as stat64, truncate as truncate64,
+};
+
+#[cfg(all(target_os = "linux", target_pointer_width = "32"))]
+use libc::{
+    dirent64, fstat64, fstatat64, ftruncate64, lseek64, lstat64, off64_t, open64, readdir64_r,
+    stat64, truncate64,
+};
 
 #[no_mangle]
 pub extern "C" fn u_open_ocall(error: *mut c_int, pathname: *const c_char, flags: c_int) -> c_int {
@@ -44,7 +55,7 @@ pub extern "C" fn u_open64_ocall(
     mode: c_int,
 ) -> c_int {
     let mut errno = 0;
-    let ret = unsafe { libc::open64(path, oflag, mode) };
+    let ret = unsafe { open64(path, oflag, mode) };
     if ret < 0 {
         errno = Error::last_os_error().raw_os_error().unwrap_or(0);
     }
@@ -94,7 +105,7 @@ pub extern "C" fn u_fstat_ocall(error: *mut c_int, fd: c_int, buf: *mut stat) ->
 #[no_mangle]
 pub extern "C" fn u_fstat64_ocall(error: *mut c_int, fd: c_int, buf: *mut stat64) -> c_int {
     let mut errno = 0;
-    let ret = unsafe { libc::fstat64(fd, buf) };
+    let ret = unsafe { fstat64(fd, buf) };
     if ret < 0 {
         errno = Error::last_os_error().raw_os_error().unwrap_or(0);
     }
@@ -128,7 +139,7 @@ pub extern "C" fn u_stat64_ocall(
     buf: *mut stat64,
 ) -> c_int {
     let mut errno = 0;
-    let ret = unsafe { libc::stat64(path, buf) };
+    let ret = unsafe { stat64(path, buf) };
     if ret < 0 {
         errno = Error::last_os_error().raw_os_error().unwrap_or(0);
     }
@@ -162,7 +173,7 @@ pub extern "C" fn u_lstat64_ocall(
     buf: *mut stat64,
 ) -> c_int {
     let mut errno = 0;
-    let ret = unsafe { libc::lstat64(path, buf) };
+    let ret = unsafe { lstat64(path, buf) };
     if ret < 0 {
         errno = Error::last_os_error().raw_os_error().unwrap_or(0);
     }
@@ -202,7 +213,7 @@ pub extern "C" fn u_lseek64_ocall(
     whence: c_int,
 ) -> off64_t {
     let mut errno = 0;
-    let ret = unsafe { libc::lseek64(fd, offset, whence) };
+    let ret = unsafe { lseek64(fd, offset, whence) };
     if ret < 0 {
         errno = Error::last_os_error().raw_os_error().unwrap_or(0);
     }
@@ -232,7 +243,7 @@ pub extern "C" fn u_ftruncate_ocall(error: *mut c_int, fd: c_int, length: off_t)
 #[no_mangle]
 pub extern "C" fn u_ftruncate64_ocall(error: *mut c_int, fd: c_int, length: off64_t) -> c_int {
     let mut errno = 0;
-    let ret = unsafe { libc::ftruncate64(fd, length) };
+    let ret = unsafe { ftruncate64(fd, length) };
     if ret < 0 {
         errno = Error::last_os_error().raw_os_error().unwrap_or(0);
     }
@@ -266,7 +277,7 @@ pub extern "C" fn u_truncate64_ocall(
     length: off64_t,
 ) -> c_int {
     let mut errno = 0;
-    let ret = unsafe { libc::truncate64(path, length) };
+    let ret = unsafe { truncate64(path, length) };
     if ret < 0 {
         errno = Error::last_os_error().raw_os_error().unwrap_or(0);
     }
@@ -553,7 +564,7 @@ pub extern "C" fn u_readdir64_r_ocall(
     entry: *mut dirent64,
     result: *mut *mut dirent64,
 ) -> c_int {
-    unsafe { libc::readdir64_r(dirp, entry, result) }
+    unsafe { readdir64_r(dirp, entry, result) }
 }
 
 #[no_mangle]
@@ -595,7 +606,7 @@ pub extern "C" fn u_fstatat64_ocall(
     flags: c_int,
 ) -> c_int {
     let mut errno = 0;
-    let ret = unsafe { libc::fstatat64(dirfd, pathname, buf, flags) };
+    let ret = unsafe { fstatat64(dirfd, pathname, buf, flags) };
     if ret < 0 {
         errno = Error::last_os_error().raw_os_error().unwrap_or(0);
     }

--- a/sgx-urts/src/lib.rs
+++ b/sgx-urts/src/lib.rs
@@ -18,6 +18,9 @@
 #![cfg_attr(feature = "signal", feature(linkage))]
 #![allow(clippy::not_unsafe_ptr_arg_deref)]
 
+#[macro_use]
+mod macros;
+
 pub mod asyncio;
 pub mod env;
 pub mod event;

--- a/sgx-urts/src/macros.rs
+++ b/sgx-urts/src/macros.rs
@@ -1,0 +1,48 @@
+/// Define an ocall function that only has a real implementation on Linux.
+/// On non-Linux targets, sets `*error = ENOSYS` and returns `-1`.
+///
+/// # Example
+///
+/// ```ignore
+/// linux_only_ocall! {
+///     pub extern "C" fn u_epoll_create1_ocall(error: *mut c_int, flags: c_int) -> c_int {
+///         let mut errno = 0;
+///         let ret = unsafe { libc::epoll_create1(flags) };
+///         if ret < 0 {
+///             errno = Error::last_os_error().raw_os_error().unwrap_or(0);
+///         }
+///         if !error.is_null() {
+///             unsafe {
+///                 *error = errno;
+///             }
+///         }
+///         ret
+///     }
+/// }
+/// ```
+macro_rules! linux_only_ocall {
+    (
+        pub extern "C" fn $name:ident(
+            $error:ident: *mut c_int
+            $(, $param:ident: $ty:ty)* $(,)?
+        ) -> $ret:ty
+            $linux_body:block
+    ) => {
+        #[cfg_attr(not(target_os = "linux"), allow(unused_variables))]
+        #[no_mangle]
+        pub extern "C" fn $name($error: *mut c_int $(, $param: $ty)*) -> $ret {
+            #[cfg(target_os = "linux")]
+            $linux_body
+
+            #[cfg(not(target_os = "linux"))]
+            {
+                if !$error.is_null() {
+                    unsafe {
+                        *$error = libc::ENOSYS;
+                    }
+                }
+                return -1;
+            }
+        }
+    };
+}

--- a/sgx-urts/src/pipe.rs
+++ b/sgx-urts/src/pipe.rs
@@ -33,17 +33,18 @@ pub extern "C" fn u_pipe_ocall(error: *mut c_int, fds: *mut c_int) -> c_int {
     ret
 }
 
-#[no_mangle]
-pub extern "C" fn u_pipe2_ocall(error: *mut c_int, fds: *mut c_int, flags: c_int) -> c_int {
-    let mut errno = 0;
-    let ret = unsafe { libc::pipe2(fds, flags) };
-    if ret < 0 {
-        errno = Error::last_os_error().raw_os_error().unwrap_or(0);
-    }
-    if !error.is_null() {
-        unsafe {
-            *error = errno;
+linux_only_ocall! {
+    pub extern "C" fn u_pipe2_ocall(error: *mut c_int, fds: *mut c_int, flags: c_int) -> c_int {
+        let mut errno = 0;
+        let ret = unsafe { libc::pipe2(fds, flags) };
+        if ret < 0 {
+            errno = Error::last_os_error().raw_os_error().unwrap_or(0);
         }
+        if !error.is_null() {
+            unsafe {
+                *error = errno;
+            }
+        }
+        ret
     }
-    ret
 }

--- a/sgx-urts/src/socket.rs
+++ b/sgx-urts/src/socket.rs
@@ -116,27 +116,28 @@ pub extern "C" fn u_accept_ocall(
     ret
 }
 
-#[no_mangle]
-pub extern "C" fn u_accept4_ocall(
-    error: *mut c_int,
-    sockfd: c_int,
-    addr: *mut sockaddr,
-    addrlen_in: socklen_t,
-    addrlen_out: *mut socklen_t,
-    flags: c_int,
-) -> c_int {
-    let mut errno = 0;
-    unsafe { *addrlen_out = addrlen_in };
-    let ret = unsafe { libc::accept4(sockfd, addr, addrlen_out, flags) };
-    if ret < 0 {
-        errno = Error::last_os_error().raw_os_error().unwrap_or(0);
-    }
-    if !error.is_null() {
-        unsafe {
-            *error = errno;
+linux_only_ocall! {
+    pub extern "C" fn u_accept4_ocall(
+        error: *mut c_int,
+        sockfd: c_int,
+        addr: *mut sockaddr,
+        addrlen_in: socklen_t,
+        addrlen_out: *mut socklen_t,
+        flags: c_int,
+    ) -> c_int {
+        let mut errno = 0;
+        unsafe { *addrlen_out = addrlen_in };
+        let ret = unsafe { libc::accept4(sockfd, addr, addrlen_out, flags) };
+        if ret < 0 {
+            errno = Error::last_os_error().raw_os_error().unwrap_or(0);
         }
+        if !error.is_null() {
+            unsafe {
+                *error = errno;
+            }
+        }
+        ret
     }
-    ret
 }
 
 #[no_mangle]

--- a/sgx-urts/src/socket.rs
+++ b/sgx-urts/src/socket.rs
@@ -229,6 +229,26 @@ pub extern "C" fn u_recvmsg_ocall(
         return -1;
     }
 
+    #[cfg(not(target_os = "linux"))]
+    let Ok(msg_iovlen) = msg_iovlen.try_into() else {
+        if !error.is_null() {
+            unsafe {
+                *error = libc::EINVAL;
+            }
+        }
+        return -1;
+    };
+
+    #[cfg(not(target_os = "linux"))]
+    let Ok(msg_controllen) = msg_controllen.try_into() else {
+        if !error.is_null() {
+            unsafe {
+                *error = libc::EINVAL;
+            }
+        }
+        return -1;
+    };
+
     let mut errno = 0;
     let mut msg = msghdr {
         msg_name,
@@ -245,8 +265,17 @@ pub extern "C" fn u_recvmsg_ocall(
     } else {
         unsafe {
             *msg_namelen_out = msg.msg_namelen;
-            *msg_controllen_out = msg.msg_controllen;
             *msg_flags = msg.msg_flags;
+
+            #[cfg(target_os = "linux")]
+            {
+                *msg_controllen_out = msg.msg_controllen;
+            }
+
+            #[cfg(not(target_os = "linux"))]
+            {
+                *msg_controllen_out = msg.msg_controllen as usize;
+            }
         }
     }
 
@@ -315,6 +344,27 @@ pub extern "C" fn u_sendmsg_ocall(
     flags: c_int,
 ) -> ssize_t {
     let mut errno = 0;
+
+    #[cfg(not(target_os = "linux"))]
+    let Ok(msg_iovlen) = msg_iovlen.try_into() else {
+        if !error.is_null() {
+            unsafe {
+                *error = libc::EINVAL;
+            }
+        }
+        return -1;
+    };
+
+    #[cfg(not(target_os = "linux"))]
+    let Ok(msg_controllen) = msg_controllen.try_into() else {
+        if !error.is_null() {
+            unsafe {
+                *error = libc::EINVAL;
+            }
+        }
+        return -1;
+    };
+
     let msg = msghdr {
         msg_name,
         msg_namelen,

--- a/sgx-urts/src/sys.rs
+++ b/sgx-urts/src/sys.rs
@@ -15,8 +15,15 @@
 // specific language governing permissions and limitations
 // under the License..
 
-use libc::{self, c_int, c_long, c_ulong, cpu_set_t, pid_t, size_t};
+use libc::{self, c_int, c_long, c_ulong, pid_t, size_t};
 use std::io::Error;
+
+#[cfg(target_os = "linux")]
+use libc::cpu_set_t;
+
+#[cfg(not(target_os = "linux"))]
+#[allow(non_camel_case_types)]
+type cpu_set_t = libc::c_void;
 
 #[no_mangle]
 pub extern "C" fn u_sysconf_ocall(error: *mut c_int, name: c_int) -> c_long {
@@ -33,64 +40,67 @@ pub extern "C" fn u_sysconf_ocall(error: *mut c_int, name: c_int) -> c_long {
     ret
 }
 
-#[no_mangle]
-pub extern "C" fn u_prctl_ocall(
-    error: *mut c_int,
-    option: c_int,
-    arg2: c_ulong,
-    arg3: c_ulong,
-    arg4: c_ulong,
-    arg5: c_ulong,
-) -> c_int {
-    let mut errno = 0;
-    let ret = unsafe { libc::prctl(option, arg2, arg3, arg4, arg5) };
-    if ret < 0 {
-        errno = Error::last_os_error().raw_os_error().unwrap_or(0);
-    }
-    if !error.is_null() {
-        unsafe {
-            *error = errno;
+linux_only_ocall! {
+    pub extern "C" fn u_prctl_ocall(
+        error: *mut c_int,
+        option: c_int,
+        arg2: c_ulong,
+        arg3: c_ulong,
+        arg4: c_ulong,
+        arg5: c_ulong,
+    ) -> c_int {
+        let mut errno = 0;
+        let ret = unsafe { libc::prctl(option, arg2, arg3, arg4, arg5) };
+        if ret < 0 {
+            errno = Error::last_os_error().raw_os_error().unwrap_or(0);
         }
+        if !error.is_null() {
+            unsafe {
+                *error = errno;
+            }
+        }
+        ret
     }
-    ret
 }
 
-#[no_mangle]
-pub extern "C" fn u_sched_setaffinity_ocall(
-    error: *mut c_int,
-    pid: pid_t,
-    cpusetsize: size_t,
-    mask: *const cpu_set_t,
-) -> c_int {
-    let mut errno = 0;
-    let ret = unsafe { libc::sched_setaffinity(pid, cpusetsize, mask) };
-    if ret < 0 {
-        errno = Error::last_os_error().raw_os_error().unwrap_or(0);
-    }
-    if !error.is_null() {
-        unsafe {
-            *error = errno;
+linux_only_ocall! {
+    pub extern "C" fn u_sched_setaffinity_ocall(
+        error: *mut c_int,
+        pid: pid_t,
+        cpusetsize: size_t,
+        mask: *const cpu_set_t,
+    ) -> c_int {
+        let mut errno = 0;
+        let ret = unsafe { libc::sched_setaffinity(pid, cpusetsize, mask) };
+        if ret < 0 {
+            errno = Error::last_os_error().raw_os_error().unwrap_or(0);
         }
+        if !error.is_null() {
+            unsafe {
+                *error = errno;
+            }
+        }
+        ret
     }
-    ret
 }
 
-#[no_mangle]
-pub extern "C" fn u_sched_getaffinity_ocall(
-    error: *mut c_int,
-    pid: pid_t,
-    cpusetsize: size_t,
-    mask: *mut cpu_set_t,
-) -> c_int {
-    let mut errno = 0;
-    let ret = unsafe { libc::sched_getaffinity(pid, cpusetsize, mask) };
-    if ret < 0 {
-        errno = Error::last_os_error().raw_os_error().unwrap_or(0);
-    }
-    if !error.is_null() {
-        unsafe {
-            *error = errno;
+linux_only_ocall! {
+    pub extern "C" fn u_sched_getaffinity_ocall(
+        error: *mut c_int,
+        pid: pid_t,
+        cpusetsize: size_t,
+        mask: *mut cpu_set_t,
+    ) -> c_int {
+        let mut errno = 0;
+        let ret = unsafe { libc::sched_getaffinity(pid, cpusetsize, mask) };
+        if ret < 0 {
+            errno = Error::last_os_error().raw_os_error().unwrap_or(0);
         }
+        if !error.is_null() {
+            unsafe {
+                *error = errno;
+            }
+        }
+        ret
     }
-    ret
 }


### PR DESCRIPTION
This allows compiling the packages in this project under `aarch64` using SW mode, with the goal of letting developers test and debug locally.

This PR also includes some changes that reduce, but don't eliminate, compilation errors on Mac OS. However, the main goal of this PR is just adding `aarch64` support on Linux (using e.g. Docker).